### PR TITLE
added workaround for suncalc bug #11

### DIFF
--- a/suncron.js
+++ b/suncron.js
@@ -30,8 +30,11 @@ module.exports = function (RED) {
 
     const calcScheduleForToday = function () {
       let today = new Date()
-      let sunTimes = SunCalc.getTimes(today, config.lat, config.lon)
-
+      const midday = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 12, 0, 0, 0, 0)
+      debug(`calcScheduleForToday():  today=` + today.toISOString())
+      debug(`calcScheduleForToday(): midday=` + midday.toISOString())
+      let sunTimes = SunCalc.getTimes(midday, config.lat, config.lon)
+      
       return eventTypes.reduce((result, eventType) => {
         const payload = config[`${eventType}Payload`]
 
@@ -62,6 +65,7 @@ module.exports = function (RED) {
             payloadType,
             topic
           }
+        debug(`event at: ` + cronTime.toISOString())
         }
         return result
       }, {})


### PR DESCRIPTION
For me, suncron only worked on the first day. On the second day, no events happened.
I added some debug code, and found this:

25 Sep 00:00:05 - [warn] [suncron:Sonne] calcScheduleForToday()
25 Sep 00:00:05 - [warn] [suncron:Sonne] today: 2019-09-24T22:00:05.300Z
25 Sep 00:00:05 - [warn] [suncron:Sonne] event at 2019-09-24T04:17:27.766Z
25 Sep 00:00:05 - [warn] [suncron:Sonne] event at 2019-09-24T15:18:09.241Z
25 Sep 00:00:05 - [warn] [suncron:Sonne] 1 msg crons deleted
25 Sep 00:00:05 - [warn] [suncron:Sonne] sunriseEnd: WARNING: Date in past. Will never be fired.
25 Sep 00:00:05 - [warn] [suncron:Sonne] sunsetStart: WARNING: Date in past. Will never be fired.
25 Sep 00:00:05 - [warn] [suncron:Sonne] 2 msg crons installed

The cron-job ran on September 25 00:00:05 local time. 'today' is in UTC, still September 24. And suncalc calculates events for September 24.

I believe this is due to this issue in suncalc:
https://github.com/mourner/suncalc/issues/11

I added the workaround, and it works for me.